### PR TITLE
make output conform to gofmt standard

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -57,7 +57,6 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-
 `)
 	return err
 }


### PR DESCRIPTION
Map values should be space-aligned against all other adjacent
non-composite values.  The initial line of a composite value should not
be space aligned, and child members of composite values should be
indented.  Blank line emission also needed to be tweaked.

Failure of prior version to conform to gofmt standard can be
demonstrated by creating the following file/directory structure,
running go-bindata, and then running "go fmt".

    a
    bb
    ccc
    ccc/a
    dddd
    eeeee
    f
    g
    g/a