### PR TITLE
Fix installation instruction for go 1.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ output being generated.
 
 To install the library and command line program, use the following:
 
-	go get -u github.com/go-bindata/go-bindata/...
-
+- (go < 1.11) `go get -u github.com/go-bindata/go-bindata/...`
+- (go >= 1.11) `go get -u github.com/go-bindata/go-bindata/go-bindata`
 
 ### Usage
 


### PR DESCRIPTION
Go 1.11 prints the following error message when trying to install with
the old instruction:

```sh
$ go get -u github.com/go-bindata/go-bindata/...

package github.com/go-bindata/go-bindata/...: github.com/go-bindata/go-bindata/...: invalid import path: malformed import path "github.com/go-bindata/go-bindata/...": double dot
``