### PR TITLE
support generate create http.FileSystem instance code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Goland project files
+.idea/
+*.iml

--- a/config.go
+++ b/config.go
@@ -106,6 +106,10 @@ type Config struct {
 	// the file data when called. Defaults to false.
 	NoCompress bool
 
+	// HttpFileSystem means whether generate return http.FileSystem interface
+	// instance's function.When true,will generate relate code.
+	HttpFileSystem bool
+
 	// Perform a debug build. This generates an asset file, which
 	// loads the asset contents directly from disk at their original
 	// location, instead of embedding the contents in the code.
@@ -148,6 +152,7 @@ func NewConfig() *Config {
 	c.Package = "main"
 	c.NoMemCopy = false
 	c.NoCompress = false
+	c.HttpFileSystem = false
 	c.Debug = false
 	c.Output = "./bindata.go"
 	c.Ignore = make([]*regexp.Regexp, 0)

--- a/debug.go
+++ b/debug.go
@@ -11,7 +11,12 @@ import (
 
 // writeDebug writes the debug code file.
 func writeDebug(w io.Writer, c *Config, toc []Asset) error {
-	err := writeDebugHeader(w)
+	err := writeDebugHeader(w, c)
+	if err != nil {
+		return err
+	}
+
+	err = writeAssetFS(w, c)
 	if err != nil {
 		return err
 	}
@@ -28,13 +33,29 @@ func writeDebug(w io.Writer, c *Config, toc []Asset) error {
 
 // writeDebugHeader writes output file headers.
 // This targets debug builds.
-func writeDebugHeader(w io.Writer) error {
-	_, err := fmt.Fprintf(w, `import (
+func writeDebugHeader(w io.Writer, c *Config) error {
+	var header string
+
+	if c.HttpFileSystem {
+		header = `import (
+	"bytes"
+	"net/http"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"`
+	} else {
+		header = `import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"`
+	}
+
+	_, err := fmt.Fprintf(w, `%s
 )
 
 // bindataRead reads the given file from disk. It returns an error on failure.
@@ -51,7 +72,7 @@ type asset struct {
 	info  os.FileInfo
 }
 
-`)
+`, header)
 	return err
 }
 

--- a/file.go
+++ b/file.go
@@ -1,0 +1,102 @@
+package bindata
+
+import (
+	"fmt"
+	"io"
+)
+
+func writeAssetFS(w io.Writer, c *Config) error {
+	if !c.HttpFileSystem {
+		return nil
+	}
+
+	_, err := fmt.Fprintf(w, `
+type assetFile struct {
+	*bytes.Reader
+	name            string
+	childInfos      []os.FileInfo
+	childInfoOffset int
+}
+
+type assetOperator struct{}
+
+// Open implement http.FileSystem interface
+func (f *assetOperator) Open(name string) (http.File, error) {
+	var err error
+	if len(name) > 0 && name[0] == '/' {
+		name = name[1:]
+	}
+	content, err := Asset(name)
+	if err == nil {
+		return &assetFile{name: name, Reader: bytes.NewReader(content)}, nil
+	}
+	children, err := AssetDir(name)
+	if err == nil {
+		childInfos := make([]os.FileInfo, 0, len(children))
+		for _, child := range children {
+			childPath := filepath.Join(name, child)
+			info, errInfo := AssetInfo(filepath.Join(name, child))
+			if errInfo == nil {
+				childInfos = append(childInfos, info)
+			} else {
+				childInfos = append(childInfos, newDirFileInfo(childPath))
+			}
+		}
+		return &assetFile{name: name, childInfos: childInfos}, nil
+	} else {
+		// If the error is not found, return an error that will
+		// result in a 404 error. Otherwise the server returns
+		// a 500 error for files not found.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+}
+
+// Close no need do anything
+func (f *assetFile) Close() error {
+	return nil
+}
+
+// Readdir read dir's children file info
+func (f *assetFile) Readdir(count int) ([]os.FileInfo, error) {
+	if len(f.childInfos) == 0 {
+		return nil, os.ErrNotExist
+	}
+	if count <= 0 {
+		return f.childInfos, nil
+	}
+	if f.childInfoOffset+count > len(f.childInfos) {
+		count = len(f.childInfos) - f.childInfoOffset
+	}
+	offset := f.childInfoOffset
+	f.childInfoOffset += count
+	return f.childInfos[offset : offset+count], nil
+}
+
+// Stat read file info from asset item
+func (f *assetFile) Stat() (os.FileInfo, error) {
+	if len(f.childInfos) != 0 {
+		return newDirFileInfo(f.name), nil
+	}
+	return AssetInfo(f.name)
+}
+
+// newDirFileInfo return default dir file info
+func newDirFileInfo(name string) os.FileInfo {
+	return &bindataFileInfo{
+		name:    name,
+		size:    0,
+		mode:    os.FileMode(2147484068), // equal os.FileMode(0644)|os.ModeDir
+		modTime: time.Time{}}
+}
+
+// AssetFile return a http.FileSystem instance that data backend by asset
+func AssetFile() http.FileSystem {
+	return &assetOperator{}
+}
+
+`)
+	return err
+}

--- a/go-bindata/.gitignore
+++ b/go-bindata/.gitignore
@@ -1,0 +1,1 @@
+go-bindata

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -48,6 +48,7 @@ func parseArgs() *bindata.Config {
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
 	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
+	flag.BoolVar(&c.HttpFileSystem, "fs", c.HttpFileSystem, "Whether generate instance http.FileSystem interface code.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
 	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")


### PR DESCRIPTION
*  `-fs`  option to enable generate create http.FileSystem instance code
```bash
$ go-bindata -h
Usage: go-bindata [options] <input directories>
...
  -fs
    	Whether generate instance http.FileSystem interface code.
  -ignore value
    	Regex pattern to ignore
...
```
* AssetFile() will return a http.FileSystem instance
```
// AssetFile return a http.FileSystem instance that data backend by asset
func AssetFile() http.FileSystem {
	return &assetOperator{}
}
```