### PR TITLE
accept -modtime=0 cmdline flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,8 +135,8 @@ type Config struct {
 	NoMetadata bool
 	// When nonzero, use this as mode for all files.
 	Mode uint
-	// When nonzero, use this as unix timestamp for all files.
-	ModTime int64
+	// When not nil, use this as unix timestamp for all files.
+	ModTime *int64
 
 	// Ignores any filenames matching the regex pattern specified, e.g.
 	// path/to/file.ext will ignore only that file, or \\.gitignore

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -31,7 +31,10 @@ func main() {
 // This function exits the program with an error, if
 // any of the command line options are incorrect.
 func parseArgs() *bindata.Config {
-	var version bool
+	var (
+		version bool
+		modtime int64
+	)
 
 	c := bindata.NewConfig()
 
@@ -50,7 +53,7 @@ func parseArgs() *bindata.Config {
 	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
 	flag.BoolVar(&c.HttpFileSystem, "fs", c.HttpFileSystem, "Whether generate instance http.FileSystem interface code.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")
-	flag.Int64Var(&c.ModTime, "modtime", c.ModTime, "Optional modification unix timestamp override for all files.")
+	flag.Int64Var(&modtime, "modtime", modtime, "Optional modification unix timestamp override for all files.")
 	flag.StringVar(&c.Output, "o", c.Output, "Optional name of the output file to be generated.")
 	flag.BoolVar(&version, "version", false, "Displays version information.")
 
@@ -58,6 +61,12 @@ func parseArgs() *bindata.Config {
 	flag.Var((*AppendSliceValue)(&ignore), "ignore", "Regex pattern to ignore")
 
 	flag.Parse()
+
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "modtime" {
+			c.ModTime = &modtime
+		}
+	})
 
 	patterns := make([]*regexp.Regexp, 0)
 	for _, pattern := range ignore {

--- a/release.go
+++ b/release.go
@@ -454,8 +454,8 @@ func asset_release_common(w io.Writer, c *Config, asset *Asset) error {
 	if c.Mode > 0 {
 		mode = uint(os.ModePerm) & c.Mode
 	}
-	if c.ModTime > 0 {
-		modTime = c.ModTime
+	if c.ModTime != nil {
+		modTime = *c.ModTime
 	}
 	_, err = fmt.Fprintf(w, `func %s() (*asset, error) {
 	bytes, err := %sBytes()


### PR DESCRIPTION
Currently passing -modtime=0 is ignored as config holds `.ModTime` by value.