### PR TITLE
add NoUnpack option

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,6 +106,10 @@ type Config struct {
 	// the file data when called. Defaults to false.
 	NoCompress bool
 
+	// NoUnpack means the assets are /not/ uncompressed before being turned
+	// into Go code of compress option enabled. Defaults to false.
+	NoUnpack bool
+
 	// HttpFileSystem means whether generate return http.FileSystem interface
 	// instance's function.When true,will generate relate code.
 	HttpFileSystem bool

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -47,6 +47,7 @@ func parseArgs() *bindata.Config {
 	flag.StringVar(&c.Package, "pkg", c.Package, "Package name to use in the generated code.")
 	flag.BoolVar(&c.NoMemCopy, "nomemcopy", c.NoMemCopy, "Use a .rodata hack to get rid of unnecessary memcopies. Refer to the documentation to see what implications this carries.")
 	flag.BoolVar(&c.NoCompress, "nocompress", c.NoCompress, "Assets will *not* be GZIP compressed when this flag is specified.")
+	flag.BoolVar(&c.NoUnpack, "nounpack", c.NoUnpack, "Assets will *not* be uncompressed when this flag is specified.")
 	flag.BoolVar(&c.NoMetadata, "nometadata", c.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
 	flag.BoolVar(&c.HttpFileSystem, "fs", c.HttpFileSystem, "Whether generate instance http.FileSystem interface code.")
 	flag.UintVar(&c.Mode, "mode", c.Mode, "Optional file mode override for all files.")


### PR DESCRIPTION
NoUnpack option could be used for web-site serving in gzip encoded resources.

Here is the example for nuxt web-site generator:
```
# it will generate web-site in to folder 'dist/'
npm run build

# it will generate resources and file system that will return compressed assets
go-bindata -pkg web -o web/bindata.go -fs -nounpack -prefix "dist/" dist/...
```

golang code:
```
// this handler will setup encoding header
type gzipHandler struct {
    handler http.Handler
}

func (t* gzipHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
    w.Header().Set("Content-Encoding", "gzip")
    t.handler.ServeHTTP(w, r)
}
```

// you can serve the web-site by this single command
mux.Handle("/", &gzipHandler {http.FileServer(web.AssetFile())})
