### PR TITLE
Use the cleaned asset name in the comment output to not to leak the r…

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -57,20 +57,11 @@ func Translate(c *Config) error {
 		return err
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	for _, asset := range toc {
-		relative, _ := filepath.Rel(wd, asset.Path)
-		if _, err = fmt.Fprintf(bfd, "// %s\n", filepath.ToSlash(relative)); err != nil {
+		if _, err = fmt.Fprintf(bfd, "// %s\n", filepath.ToSlash(asset.Name)); err != nil {
 			return err
 		}
 	}
-	//if _, err = fmt.Fprint(bfd, "// DO NOT EDIT!\n\n"); err != nil {
-	//	return err
-	//}
 
 	// Write build tags, if applicable.
 	if len(c.Tags) > 0 {


### PR DESCRIPTION
When using the `-prefix` flag it is correctly stripped from the source file mappings, however, the comments on the very top still contain the prefix. This PR will use the cleaned asset name as the file path in the comments (issue #56)