### PR TITLE
Fix module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ output being generated.
 
 To install the library and command line program, use the following:
 
-	go get -u github.com/go-bindata/go-bindata/...
+	go get -u github.com/go-bindata/go-bindata/v3/...
 
 
 ### Usage


### PR DESCRIPTION
In order to build latest (v3.1.3) version, "v3" suffix is required to match
module name specified in `go.mod` (i.e. `github.com/go-bindata/go-bindata/v3`).

Without "v3" (`go get -u github.com/go-bindata/go-bindata/...`) builds
v3.1.2 version of `go-bindata`.