### PR TITLE
Make *Bytes() function public

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -6,7 +6,8 @@ package bindata
 
 // Asset holds information about a single asset to be processed.
 type Asset struct {
-	Path string // Full file path.
-	Name string // Key used in TOC -- name by which asset is referenced.
-	Func string // Function name for the procedure returning the asset contents.
+	Path    string // Full file path.
+	Name    string // Key used in TOC -- name by which asset is referenced.
+	Func    string // Function name for the procedure returning the asset contents.
+	PubFunc string // Public function name for the procedure returning the asset contents.
 }

--- a/convert.go
+++ b/convert.go
@@ -211,7 +211,8 @@ func findFiles(dir, prefix string, recursive bool, toc *[]Asset, ignore []*regex
 			return fmt.Errorf("invalid file: %v", asset.Path)
 		}
 
-		asset.Func = safeFunctionName(asset.Name, knownFuncs)
+		asset.Func = safeFunctionName(asset.Name, false, knownFuncs)
+		asset.PubFunc = safeFunctionName(asset.Name, true, knownFuncs)
 		asset.Path, _ = filepath.Abs(asset.Path)
 		*toc = append(*toc, asset)
 	}
@@ -225,9 +226,8 @@ var regFuncName = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 // which qualifies as a valid function identifier. It
 // also compares against a known list of functions to
 // prevent conflict based on name translation.
-func safeFunctionName(name string, knownFuncs map[string]int) string {
+func safeFunctionName(name string, toUpper bool, knownFuncs map[string]int) string {
 	var inBytes, outBytes []byte
-	var toUpper bool
 
 	name = strings.ToLower(name)
 	inBytes = []byte(name)

--- a/release.go
+++ b/release.go
@@ -356,7 +356,7 @@ func %sBytes() ([]byte, error) {
 	)
 }
 
-`, asset.Func, asset.Func, asset.Name)
+`, asset.PubFunc, asset.Func, asset.Name)
 	return err
 }
 
@@ -383,7 +383,7 @@ func %sBytes() ([]byte, error) {
 	)
 }
 
-`, asset.Func, asset.Func, asset.Name)
+`, asset.PubFunc, asset.Func, asset.Name)
 	return err
 }
 
@@ -407,7 +407,7 @@ func %sBytes() ([]byte, error) {
 	)
 }
 
-`, asset.Func, asset.Func, asset.Name)
+`, asset.PubFunc, asset.Func, asset.Name)
 	return err
 }
 
@@ -433,7 +433,7 @@ func %sBytes() ([]byte, error) {
 	return _%s, nil
 }
 
-`, asset.Func, asset.Func)
+`, asset.PubFunc, asset.Func)
 	return err
 }
 
@@ -468,6 +468,6 @@ func asset_release_common(w io.Writer, c *Config, asset *Asset) error {
 	return a, nil
 }
 
-`, asset.Func, asset.Func, asset.Name, size, mode, modTime)
+`, asset.Func, asset.PubFunc, asset.Name, size, mode, modTime)
 	return err
 }

--- a/testdata/out/compress-memcopy.go
+++ b/testdata/out/compress-memcopy.go
@@ -82,7 +82,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 
 var _inATestAsset = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00")
 
-func inATestAssetBytes() ([]byte, error) {
+func InATestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inATestAsset,
 		"in/a/test.asset",
@@ -90,7 +90,7 @@ func inATestAssetBytes() ([]byte, error) {
 }
 
 func inATestAsset() (*asset, error) {
-	bytes, err := inATestAssetBytes()
+	bytes, err := InATestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func inATestAsset() (*asset, error) {
 
 var _inBTestAsset = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00")
 
-func inBTestAssetBytes() ([]byte, error) {
+func InBTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inBTestAsset,
 		"in/b/test.asset",
@@ -110,7 +110,7 @@ func inBTestAssetBytes() ([]byte, error) {
 }
 
 func inBTestAsset() (*asset, error) {
-	bytes, err := inBTestAssetBytes()
+	bytes, err := InBTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func inBTestAsset() (*asset, error) {
 
 var _inCTestAsset = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00")
 
-func inCTestAssetBytes() ([]byte, error) {
+func InCTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inCTestAsset,
 		"in/c/test.asset",
@@ -130,7 +130,7 @@ func inCTestAssetBytes() ([]byte, error) {
 }
 
 func inCTestAsset() (*asset, error) {
-	bytes, err := inCTestAssetBytes()
+	bytes, err := InCTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func inCTestAsset() (*asset, error) {
 
 var _inTestAsset = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00")
 
-func inTestAssetBytes() ([]byte, error) {
+func InTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inTestAsset,
 		"in/test.asset",
@@ -150,7 +150,7 @@ func inTestAssetBytes() ([]byte, error) {
 }
 
 func inTestAsset() (*asset, error) {
-	bytes, err := inTestAssetBytes()
+	bytes, err := InTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/out/compress-nomemcopy.go
+++ b/testdata/out/compress-nomemcopy.go
@@ -82,7 +82,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 
 var _inATestAsset = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00"
 
-func inATestAssetBytes() ([]byte, error) {
+func InATestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inATestAsset,
 		"in/a/test.asset",
@@ -90,7 +90,7 @@ func inATestAssetBytes() ([]byte, error) {
 }
 
 func inATestAsset() (*asset, error) {
-	bytes, err := inATestAssetBytes()
+	bytes, err := InATestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func inATestAsset() (*asset, error) {
 
 var _inBTestAsset = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00"
 
-func inBTestAssetBytes() ([]byte, error) {
+func InBTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inBTestAsset,
 		"in/b/test.asset",
@@ -110,7 +110,7 @@ func inBTestAssetBytes() ([]byte, error) {
 }
 
 func inBTestAsset() (*asset, error) {
-	bytes, err := inBTestAssetBytes()
+	bytes, err := InBTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func inBTestAsset() (*asset, error) {
 
 var _inCTestAsset = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00"
 
-func inCTestAssetBytes() ([]byte, error) {
+func InCTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inCTestAsset,
 		"in/c/test.asset",
@@ -130,7 +130,7 @@ func inCTestAssetBytes() ([]byte, error) {
 }
 
 func inCTestAsset() (*asset, error) {
-	bytes, err := inCTestAssetBytes()
+	bytes, err := InCTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func inCTestAsset() (*asset, error) {
 
 var _inTestAsset = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd7\x57\x28\x4e\xcc\x2d\xc8\x49\x55\x48\xcb\xcc\x49\xe5\x02\x04\x00\x00\xff\xff\x8a\x82\x8c\x85\x0f\x00\x00\x00"
 
-func inTestAssetBytes() ([]byte, error) {
+func InTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inTestAsset,
 		"in/test.asset",
@@ -150,7 +150,7 @@ func inTestAssetBytes() ([]byte, error) {
 }
 
 func inTestAsset() (*asset, error) {
-	bytes, err := inTestAssetBytes()
+	bytes, err := InTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/out/nocompress-memcopy.go
+++ b/testdata/out/nocompress-memcopy.go
@@ -59,12 +59,12 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _inATestAsset = []byte(`// sample file
 `)
 
-func inATestAssetBytes() ([]byte, error) {
+func InATestAssetBytes() ([]byte, error) {
 	return _inATestAsset, nil
 }
 
 func inATestAsset() (*asset, error) {
-	bytes, err := inATestAssetBytes()
+	bytes, err := InATestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -77,12 +77,12 @@ func inATestAsset() (*asset, error) {
 var _inBTestAsset = []byte(`// sample file
 `)
 
-func inBTestAssetBytes() ([]byte, error) {
+func InBTestAssetBytes() ([]byte, error) {
 	return _inBTestAsset, nil
 }
 
 func inBTestAsset() (*asset, error) {
-	bytes, err := inBTestAssetBytes()
+	bytes, err := InBTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +95,12 @@ func inBTestAsset() (*asset, error) {
 var _inCTestAsset = []byte(`// sample file
 `)
 
-func inCTestAssetBytes() ([]byte, error) {
+func InCTestAssetBytes() ([]byte, error) {
 	return _inCTestAsset, nil
 }
 
 func inCTestAsset() (*asset, error) {
-	bytes, err := inCTestAssetBytes()
+	bytes, err := InCTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -113,12 +113,12 @@ func inCTestAsset() (*asset, error) {
 var _inTestAsset = []byte(`// sample file
 `)
 
-func inTestAssetBytes() ([]byte, error) {
+func InTestAssetBytes() ([]byte, error) {
 	return _inTestAsset, nil
 }
 
 func inTestAsset() (*asset, error) {
-	bytes, err := inTestAssetBytes()
+	bytes, err := InTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/out/nocompress-nomemcopy.go
+++ b/testdata/out/nocompress-nomemcopy.go
@@ -72,7 +72,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 
 var _inATestAsset = "\x2f\x2f\x20\x73\x61\x6d\x70\x6c\x65\x20\x66\x69\x6c\x65\x0a"
 
-func inATestAssetBytes() ([]byte, error) {
+func InATestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inATestAsset,
 		"in/a/test.asset",
@@ -80,7 +80,7 @@ func inATestAssetBytes() ([]byte, error) {
 }
 
 func inATestAsset() (*asset, error) {
-	bytes, err := inATestAssetBytes()
+	bytes, err := InATestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func inATestAsset() (*asset, error) {
 
 var _inBTestAsset = "\x2f\x2f\x20\x73\x61\x6d\x70\x6c\x65\x20\x66\x69\x6c\x65\x0a"
 
-func inBTestAssetBytes() ([]byte, error) {
+func InBTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inBTestAsset,
 		"in/b/test.asset",
@@ -100,7 +100,7 @@ func inBTestAssetBytes() ([]byte, error) {
 }
 
 func inBTestAsset() (*asset, error) {
-	bytes, err := inBTestAssetBytes()
+	bytes, err := InBTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func inBTestAsset() (*asset, error) {
 
 var _inCTestAsset = "\x2f\x2f\x20\x73\x61\x6d\x70\x6c\x65\x20\x66\x69\x6c\x65\x0a"
 
-func inCTestAssetBytes() ([]byte, error) {
+func InCTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inCTestAsset,
 		"in/c/test.asset",
@@ -120,7 +120,7 @@ func inCTestAssetBytes() ([]byte, error) {
 }
 
 func inCTestAsset() (*asset, error) {
-	bytes, err := inCTestAssetBytes()
+	bytes, err := InCTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func inCTestAsset() (*asset, error) {
 
 var _inTestAsset = "\x2f\x2f\x20\x73\x61\x6d\x70\x6c\x65\x20\x66\x69\x6c\x65\x0a"
 
-func inTestAssetBytes() ([]byte, error) {
+func InTestAssetBytes() ([]byte, error) {
 	return bindataRead(
 		_inTestAsset,
 		"in/test.asset",
@@ -140,7 +140,7 @@ func inTestAssetBytes() ([]byte, error) {
 }
 
 func inTestAsset() (*asset, error) {
-	bytes, err := inTestAssetBytes()
+	bytes, err := InTestAssetBytes()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Our use case is we need to send data files and scripts to run on remote
servers.  In this case the specific file used depends on the step and is
baked into the code.  If we were to use Asset("...") to reference the
file there's a chance that a typo could cause errors at runtime.

By exposing the *Bytes() function we can reference the data and the
compiler will alert us if there is a mistake.

There are some caveats with the approach in this PR:
1. If the file begins with a number the resulting files will be private.
2. If there are files with conflicting names they may
   nondeterministically get numeric suffixes.

I think these are probably acceptable.  If the scripts, data files, etc.
were provided by a third party we'd probably be accessing them
programmatically.  Since we're providing the scripts ourselves we can
explicitly give them non-conflicting names.

Also I wasn't sure if the test data should be merged.  The generated files leaked personal information so I cleaned that up, leaving only the relevant changes (I'm not sure how to easily test though without recreating them again). 