### PR TITLE
remove redundant type in map literal

### DIFF
--- a/toc.go
+++ b/toc.go
@@ -87,7 +87,10 @@ func getFillerSize(tokenIndex int, lengths []int, nident int) int {
 }
 
 func (root *assetTree) writeGoMap(w io.Writer, nident int) {
-	fmt.Fprintf(w, "&bintree{%s, map[string]*bintree{", root.funcOrNil())
+	if nident == 0 {
+		fmt.Fprint(w, "&bintree")
+	}
+	fmt.Fprintf(w, "{%s, map[string]*bintree{", root.funcOrNil())
 
 	if len(root.Children) > 0 {
 		io.WriteString(w, "\n")


### PR DESCRIPTION
Having the type named inside the literal is not necessary, and will cause linter warnings from the `simplifycompositelit` linter for example.