### PR TITLE
fix readme about install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ output being generated.
 
 To install the library and command line program, use the following:
 
-	go get -u github.com/go-bindata/go-bindata/...
+	go install github.com/go-bindata/go-bindata/...
 
 
 ### Usage


### PR DESCRIPTION
`go get -u github.com/go-bindata/go-bindata/...` doesn't do the install for me, but `go install github.com/go-bindata/go-bindata/...` does.